### PR TITLE
Add support for redirect to url without protocol

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -437,7 +437,15 @@ namespace Xamarin.Android.Net
 			if (redirectState.RedirectCounter >= MaxAutomaticRedirections)
 				throw new WebException ($"Maximum automatic redirections exceeded (allowed {MaxAutomaticRedirections}, redirected {redirectState.RedirectCounter} times)");
 
-			Uri location = new Uri (locationHeader [0], UriKind.Absolute);
+			string redirectUrl = locationHeader[0];
+			string protocol = httpConnection.URL?.Protocol;
+			if (redirectUrl.StartsWith("//") && protocol != null && protocol.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+			{
+				// When redirecting to an URL without protocol, we use the protocol of previous request
+				redirectUrl = protocol + ":" + redirectUrl;
+			}
+			
+			Uri location = new Uri (redirectUrl, UriKind.Absolute);
 			redirectState.NewUrl = location;
 			if (Logger.LogNet)
 				Logger.Log (LogLevel.Debug, LOG_APP, $"Request redirected to {location}");


### PR DESCRIPTION
This commit adds support for redirecting to urls that
do not specify a scheme. In such cases, the scheme
of the previous request is used.

For example, a request to http://example.com/redirect
may return a 301 redirect to //example.com/new_site.
In this case, we should keep speaking http and retrieve
http://example.com/new_site